### PR TITLE
Keeping only relevant code for iOS 11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Apple File Conduit "2" (iOS 11+, arm64)
 =======================================
 
-**Works on any arm64 device running iOS 11, 12, and 13.**
+**Works on any arm64 device running iOS 11 and higher.**
 
 This is a modified version of saurik's original AFC2 code that downloads and installs an arm64 copy of afcd (required on iOS 11 and above) straight from Apple, and then automatically grants it the necessary `platform-application` entitlement required for functionality on KPPLess jailbreaks (like Electra and Meridian).
 

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -1,6 +1,6 @@
 /* AFC2 - the original definition of "jailbreak"
  * Copyright (C) 2014  Jay Freeman (saurik)
- * Copyright (C) 2018 - 2019  Cannathea
+ * Copyright (C) 2018 - 2021  Cannathea
  */
 
 /* GNU General Public License, Version 3 {{{ */
@@ -21,10 +21,7 @@
 /* }}} */
 
 #import "easy_spawn.h"
-
-#ifndef kCFCoreFoundationVersionNumber_iOS_12_0
-#define kCFCoreFoundationVersionNumber_iOS_12_0 1556.00
-#endif
+#import <Foundation/Foundation.h>
 
 #define PATH @"/usr/libexec/afc2dSupport"
 
@@ -37,8 +34,7 @@
 %end %end
 
 %ctor {
-    if ((kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iOS_12_0 &&
-        [[NSFileManager defaultManager] fileExistsAtPath:@"/usr/share/jailbreak/signcert.p12"]) ||
+    if (([[NSFileManager defaultManager] fileExistsAtPath:@"/usr/share/jailbreak/signcert.p12"]) ||
         [[NSFileManager defaultManager] fileExistsAtPath:PATH]) {
         %init(SpringBoardHook);
     }

--- a/afc2dSupport.plist
+++ b/afc2dSupport.plist
@@ -1,1 +1,17 @@
-{ Filter = { Bundles = ( "com.apple.springboard" ); }; }
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Filter</key>
+	<dict>
+		<key>CoreFoundationVersion</key>
+		<array>
+			<real>1556.00</real>
+		</array>
+		<key>Bundles</key>
+		<array>
+			<string>com.apple.springboard</string>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/control
+++ b/control
@@ -1,10 +1,10 @@
 Package: com.cannathea.afc2d-arm64
 Name: Apple File Conduit "2" (iOS 11+, arm64)
-Version: 1.1.2
+Version: 1.1.3
 Description: Allow full file-system access over USB for all arm64 devices, especially useful for those on iOS 11 and above.
 Section: System
 Pre-Depends: dpkg (>= 1.14.25-8)
-Depends: cy+cpu.arm64, mobilesubstrate, ldid
+Depends: cy+cpu.arm64, mobilesubstrate, ldid, firmware (>= 11.0)
 Conflicts: com.saurik.afc2d, net.angelxwind.afc2d-arm64, com.mrmadtw.afc2forios11, repo.feng.afc2add11, us.scw.afctwoadd, net.angelxwind.afc2ios70, afc2.25pp, afc2.25pp7, afc2.91, app.taig.afc2
 Replaces: com.saurik.afc2d, net.angelxwind.afc2d-arm64, com.mrmadtw.afc2forios11, repo.feng.afc2add11, us.scw.afctwoadd, net.angelxwind.afc2ios70, afc2.25pp, afc2.25pp7, afc2.91, app.taig.afc2
 Provides: com.saurik.afc2d, net.angelxwind.afc2d-arm64, com.mrmadtw.afc2forios11, repo.feng.afc2add11, us.scw.afctwoadd, net.angelxwind.afc2ios70, afc2.25pp, afc2.25pp7, afc2.91, app.taig.afc2

--- a/easy_spawn.h
+++ b/easy_spawn.h
@@ -1,4 +1,5 @@
 #import <spawn.h>
+#include <sys/wait.h>
 
 static void easy_spawn(const char* args[]) {
     pid_t pid;

--- a/extrainst.mm
+++ b/extrainst.mm
@@ -1,6 +1,6 @@
 /* AFC2 - the original definition of "jailbreak"
  * Copyright (C) 2014  Jay Freeman (saurik)
- * Copyright (C) 2018  Cannathea
+ * Copyright (C) 2018 - 2021  Cannathea
 */
 
 /* GNU General Public License, Version 3 {{{ */
@@ -28,33 +28,11 @@
 int main(int argc, const char *argv[]) {
     if (argc < 2 || (
         strcmp(argv[1], "install") != 0 &&
-        strcmp(argv[1], "upgrade") != 0 &&
-    true)) return 0;
+        strcmp(argv[1], "upgrade") != 0)) return 0;
 
     NSAutoreleasePool *pool([[NSAutoreleasePool alloc] init]);
     
     [[NSFileManager defaultManager] createFileAtPath:PATH contents:nil attributes:nil];
-
-    if (kCFCoreFoundationVersionNumber < 1000) {
-        NSString *path(@"/System/Library/Lockdown/Services.plist");
-
-        NSMutableDictionary *services([NSMutableDictionary dictionaryWithContentsOfFile:path]);
-        if (services == nil) {
-            fprintf(stderr, "cannot read Services.plist\n");
-            return 1;
-        }
-
-        [services setObject:@{
-            @"AllowUnactivatedService": @true,
-            @"Label": @"com.apple.afc2",
-            @"ProgramArguments": @[@"/usr/libexec/afc2d", @"-S", @"-L", @"-d", @"/"],
-        } forKey:@"com.apple.afc2"];
-
-        if (![services writeToFile:path atomically:YES]) {
-            fprintf(stderr, "cannot write Services.plist\n");
-            return 1;
-        }
-    }
     
     easy_spawn((const char *[]){"chown", "root:wheel", "/usr/bin/killdaemon" , NULL});
     easy_spawn((const char *[]){"chmod", "6755", "/usr/bin/killdaemon" , NULL});

--- a/killdaemon.mm
+++ b/killdaemon.mm
@@ -1,6 +1,6 @@
 /* AFC2 - the original definition of "jailbreak"
  * Copyright (C) 2014  Jay Freeman (saurik)
- * Copyright (C) 2018 - 2019  Cannathea
+ * Copyright (C) 2018 - 2021  Cannathea
  */
 
 /* GNU General Public License, Version 3 {{{ */
@@ -23,11 +23,8 @@
 #import <Foundation/Foundation.h>
 #include <CommonCrypto/CommonDigest.h>
 #include <zlib.h>
+#import <version.h>
 #import "easy_spawn.h"
-
-#ifndef kCFCoreFoundationVersionNumber_iOS_12_0
-#define kCFCoreFoundationVersionNumber_iOS_12_0 1556.00
-#endif
 
 #define PATH @"/usr/libexec/afc2dSupport"
 
@@ -89,7 +86,7 @@ int main(int argc, const char **argv) {
         
         if ((chdir("/")) < 0) {
             printf("ERROR: Not run as root.\n");
-        } else if (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iOS_12_0 &&
+        } else if (IS_IOS_OR_NEWER(iOS_12_0) &&
                    [[NSFileManager defaultManager] fileExistsAtPath:@"/usr/share/jailbreak/signcert.p12"]) {
             easy_spawn((const char *[]){"/usr/bin/killall", "-9", "lockdownd", NULL});
         }

--- a/postrm.mm
+++ b/postrm.mm
@@ -1,6 +1,6 @@
 /* AFC2 - the original definition of "jailbreak"
  * Copyright (C) 2014  Jay Freeman (saurik)
- * Copyright (C) 2018  Cannathea
+ * Copyright (C) 2018 - 2021  Cannathea
 */
 
 /* GNU General Public License, Version 3 {{{ */
@@ -20,27 +20,16 @@
 **/
 /* }}} */
 
-#include <Foundation/Foundation.h>
 #import "easy_spawn.h"
+#include <string.h>
+#include <unistd.h>
 
 int main(int argc, const char *argv[]) {
     if (argc < 2 || (
         strcmp(argv[1], "abort-install") != 0 &&
-        strcmp(argv[1], "remove") != 0 &&
-    true)) return 0;
-
-    NSAutoreleasePool *pool([[NSAutoreleasePool alloc] init]);
-
-    NSString *path(@"/System/Library/Lockdown/Services.plist");
-    NSMutableDictionary *services([NSMutableDictionary dictionaryWithContentsOfFile:path]);
-
-    if (services != nil && [services objectForKey:@"com.apple.afc2"] != nil) {
-        [services removeObjectForKey:@"com.apple.afc2"];
-        [services writeToFile:path atomically:YES];
-    }
+        strcmp(argv[1], "remove") != 0)) return 0;
 
     easy_spawn((const char *[]){(access("/sbin/launchctl", X_OK) != -1) ? "/sbin/launchctl" : "/bin/launchctl", "stop", "com.apple.mobile.lockdown", NULL});
 
-    [pool release];
     return 0;
 }


### PR DESCRIPTION
- Removed all parts of code that will never be executed practically.
- Added and removed imports to make them support compiling with latest theos.
- Added `firmware (>= 11.0)` installation restriction.
- Improved overall logic.
- Updated copyright in the touched files.