### PR TITLE
Fix launchctl path for Dopamine

### DIFF
--- a/extrainst.mm
+++ b/extrainst.mm
@@ -128,7 +128,10 @@ int main(int argc, const char *argv[]) {
         }
 
         // stop com.apple.mobile.lockdown
-        easy_spawn((const char *[]){(access(ROOT_PATH("/sbin/launchctl"), X_OK) != -1) ? ROOT_PATH("/sbin/launchctl") : ROOT_PATH("/bin/launchctl"), "stop", "com.apple.mobile.lockdown", NULL});
+        const char *launchctl = ROOT_PATH("/sbin/launchctl");
+        if (access(launchctl, X_OK) == -1) launchctl = ROOT_PATH("/bin/launchctl");
+        if (access(launchctl, X_OK) == -1) launchctl = ROOT_PATH("/usr/bin/launchctl");
+        easy_spawn((const char *[]){launchctl, "stop", "com.apple.mobile.lockdown", NULL});
     }
     return 0;
 }


### PR DESCRIPTION
## Problem

After installing afc2, the `com.apple.afc2` service doesn't work until `lockdownd` is manually restarted (`launchctl stop com.apple.mobile.lockdown`). This is because the post-install script fails to restart lockdownd automatically.

On my installation of Dopamine, `launchctl` is located at `/var/jb/usr/bin/launchctl`, but the script only checks `/var/jb/sbin/launchctl` and `/var/jb/bin/launchctl`.

## Fix

Add `/usr/bin/launchctl` as a fallback path (expands to `/var/jb/usr/bin/launchctl` via `ROOT_PATH` on rootless).

## Testing

Tested on iPhone SE (iPhone8,4) running iOS 15.8.5 with Dopamine. After reinstalling the patched package, afc2 works immediately without manual intervention.